### PR TITLE
close #6: correctly free allocated memory

### DIFF
--- a/apt-pkg-c/lib.cpp
+++ b/apt-pkg-c/lib.cpp
@@ -146,7 +146,12 @@ extern "C" {
     const char *ver_file_parser_maintainer(PVerFileParser *parser);
     const char *ver_file_parser_homepage(PVerFileParser *parser);
 
-    // ver_file_iter has no accessors, only the creation of pkg_file_iter
+    // parser data needs manual freeing
+    void ver_file_parser_free_str(char *ptr);
+    void ver_file_parser_free(PVerFileParser *parser);
+
+    // PVerFileIterator has no accessors, only the creation of PPkgFileIterator
+    // and PVerFileParser
 
 
     // pkg_file_iter creation
@@ -369,6 +374,7 @@ PVerFileParser *ver_file_iter_get_parser(PVerFileIterator *wrapper) {
     return parser;
 }
 
+// must be freed with ver_file_parser_free_str
 const char *to_c_string(std::string s) {
     char *cstr = new char[s.length()+1];
     std::strcpy(cstr, s.c_str());
@@ -393,6 +399,14 @@ const char *ver_file_parser_maintainer(PVerFileParser *parser) {
 const char *ver_file_parser_homepage(PVerFileParser *parser) {
     std::string hp = parser->parser->Homepage();
     return to_c_string(hp);
+}
+
+void ver_file_parser_free_str(char *ptr) {
+    delete ptr;
+}
+
+void ver_file_parser_free(PVerFileParser *parser) {
+    delete parser;
 }
 
 bool ver_file_iter_end(PVerFileIterator *wrapper) {

--- a/examples/policy.rs
+++ b/examples/policy.rs
@@ -42,8 +42,11 @@ fn main() {
             #[cfg(feature = "ye-olde-apt")]
             println!(" {} {}", marker, version.version,);
 
+            println!("       {} {}", "Desc:",
+                version.details.short_desc.unwrap_or("-".to_owned()));
+
             for origin in origins {
-                println!("       {:4} {}", "XXX", origin);
+                println!("       {} {}", "Orig:", origin);
             }
         }
     } else {

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -1,7 +1,7 @@
 /// In general:
 ///  * `*mut c_void` are to be released by the appropriate function
 ///  * `*const c_chars` are short-term borrows
-///  * `*mut c_chars` are to be freed by `libc::free`.
+///  * `*mut c_chars` are to be freed by their associated 'free' function
 use std::sync::Mutex;
 
 use lazy_static::lazy_static;
@@ -65,16 +65,16 @@ extern "C" {
     // Version accessors
     // =================
 
-    pub fn ver_iter_version(iterator: PVerIterator) -> *mut c_char;
-    pub fn ver_iter_section(iterator: PVerIterator) -> *mut c_char;
+    pub fn ver_iter_version(iterator: PVerIterator) -> *const c_char;
+    pub fn ver_iter_section(iterator: PVerIterator) -> *const c_char;
 
     #[cfg(not(feature = "ye-olde-apt"))]
-    pub fn ver_iter_source_package(iterator: PVerIterator) -> *mut c_char;
+    pub fn ver_iter_source_package(iterator: PVerIterator) -> *const c_char;
 
     #[cfg(not(feature = "ye-olde-apt"))]
-    pub fn ver_iter_source_version(iterator: PVerIterator) -> *mut c_char;
-    pub fn ver_iter_arch(iterator: PVerIterator) -> *mut c_char;
-    pub fn ver_iter_priority_type(iterator: PVerIterator) -> *mut c_char;
+    pub fn ver_iter_source_version(iterator: PVerIterator) -> *const c_char;
+    pub fn ver_iter_arch(iterator: PVerIterator) -> *const c_char;
+    pub fn ver_iter_priority_type(iterator: PVerIterator) -> *const c_char;
 
     #[cfg(not(feature = "ye-olde-apt"))]
     pub fn ver_iter_priority(iterator: PVerIterator) -> i32;
@@ -103,10 +103,12 @@ extern "C" {
     pub fn ver_file_iter_end(iterator: PVerFileIterator) -> bool;
 
     pub fn ver_file_iter_get_parser(iterator: PVerFileIterator) -> PVerFileParser;
-    pub fn ver_file_parser_short_desc(parser: PVerFileParser) -> *const c_char;
-    pub fn ver_file_parser_long_desc(parser: PVerFileParser) -> *const c_char;
-    pub fn ver_file_parser_maintainer(parser: PVerFileParser) -> *const c_char;
-    pub fn ver_file_parser_homepage(parser: PVerFileParser) -> *const c_char;
+    pub fn ver_file_parser_short_desc(parser: PVerFileParser) -> *mut c_char;
+    pub fn ver_file_parser_long_desc(parser: PVerFileParser) -> *mut c_char;
+    pub fn ver_file_parser_maintainer(parser: PVerFileParser) -> *mut c_char;
+    pub fn ver_file_parser_homepage(parser: PVerFileParser) -> *mut c_char;
+    pub fn ver_file_parser_free_str(ptr: *mut c_char);
+    pub fn ver_file_parser_free(parser: PVerFileParser);
 
     pub fn ver_file_iter_pkg_file_iter(iterator: PVerFileIterator) -> PPkgFileIterator;
     pub fn pkg_file_iter_release(iterator: PPkgFileIterator);

--- a/src/simple.rs
+++ b/src/simple.rs
@@ -37,6 +37,25 @@ impl fmt::Display for BinaryPackage {
 }
 
 #[derive(Clone, Debug)]
+pub struct VersionDetails {
+    pub short_desc: Option<String>,
+    pub long_desc: Option<String>,
+    pub maintainer: Option<String>,
+    pub homepage: Option<String>,
+}
+
+impl Default for VersionDetails {
+    fn default() -> Self {
+        Self {
+            short_desc: None,
+            long_desc: None,
+            maintainer: None,
+            homepage: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
 pub struct Version {
     pub version: String,
     pub arch: String,
@@ -48,10 +67,24 @@ pub struct Version {
     pub source_version: String,
     #[cfg(not(feature = "ye-olde-apt"))]
     pub priority: i32,
+
+    pub details: VersionDetails,
 }
 
 impl Version {
     pub fn new(view: &sane::VerView) -> Self {
+        // assume there is either zero or only one set of details per version
+        let details = if let Some(ver_file) = view.origin_iter().next() {
+            VersionDetails {
+                short_desc: ver_file.short_desc(),
+                long_desc: ver_file.long_desc(),
+                maintainer: ver_file.maintainer(),
+                homepage: ver_file.homepage(),
+            }
+        } else {
+            Default::default()
+        };
+
         Version {
             version: view.version(),
             arch: view.arch(),
@@ -62,6 +95,7 @@ impl Version {
             source_version: view.source_version(),
             #[cfg(not(feature = "ye-olde-apt"))]
             priority: view.priority(),
+            details,
         }
     }
 }


### PR DESCRIPTION
Thanks for merging my previous PR! Here's a followup for #6.

I added `to_c_string` as an ugly workaround, and yes, it indeed does require a manual free. Turns out, the parser itself does too. Not a fan of intermingling rust memory allocation and c++ one, so I added seperate "free" functions to the lib that call delete.

To test, I extended the "policy" example and added some stuff to the simple API to ensure the new code paths are taken. Then I ran "cargo valgrind", verifying that there are indeed no memory leaks now.

Valgrind also showed my that the ones you had marked `*mut c_char` previously were in fact automatically released, so I changed them to "const" and updated the comment. I hope that's correct and libapt isn't somehow stupid about that too :)

I suppose a `impl Drop` wrapper for the returned string data (potentially `Deref<str>` or smth) would work too, but I figured we copy the string once, so might as well copy it twice and make our lives easier by just having Rust do the final free.