### PR TITLE
switch to gnu++17 to fix build with libapt-pkg-dev version 3

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,7 @@ fn main() {
     let mut build = cc::Build::new();
     build.file(SRC);
     build.cpp(true);
-    build.flag("-std=gnu++11");
+    build.flag("-std=gnu++17");
 
     #[cfg(feature = "ye-olde-apt")]
     {


### PR DESCRIPTION
While apt switched to compile with C++17 [0] already in the older version 2.3.8 (released in August 2021), it only used newer features internally but not in any public ABI/API that this crate wraps, so it continued to work fine even with newer apt-pkg library versions.

For APT 3.0 the APT_PKG_ABI was bumped, and with that bump the custom string type APT::StringView was migrated to the std::string_view one [1], which is natively available since C++17.

This is the reason why one needs to use the C++17 based gnu++17 std option when compiling this crate with a apt-pkg library in version 3.0 or newer.

GCC got support for std::string_view with its 7.1 release [2] which happened in May 2017 [3], about 8 years ago. So it's safe to switch on the newer C++ standard compiler option, as compilers supporting that should be widely available.

Note that enabling this option won't break support of compiling with an older apt-pkg version, like 2.6 from Bookworm which I tested, so this is safe to enable unconditionally.

[0]: https://salsa.debian.org/apt-team/apt/-/commit/2f510c5632ba83b97c6eb86ebf5e39085fde74fe
[1]: https://salsa.debian.org/apt-team/apt/-/merge_requests/396
[2]: https://gcc.gnu.org/onlinedocs/libstdc++/manual/status.html#status.iso.2017
[3]: https://gcc.gnu.org/gcc-7/