### PR TITLE
CI: switch to gnu++17 to fix build with libapt-pkg-dev version 3

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,7 @@ fn main() {
     let mut build = cc::Build::new();
     build.file(SRC);
     build.cpp(true);
-    build.flag("-std=gnu++11");
+    build.flag("-std=gnu++17");
 
     #[cfg(feature = "ye-olde-apt")]
     {


### PR DESCRIPTION
Copy of #9 so CI runs?